### PR TITLE
fix nondeterministic results

### DIFF
--- a/unused.go
+++ b/unused.go
@@ -434,7 +434,7 @@ func (c *Checker) consideredUsed(obj types.Object, f string) bool {
 		}
 
 		// Package-level are used, except in package main
-		if isPkgScope(obj) && c.pkg.Pkg.Name() != "main" {
+		if isPkgScope(obj) && obj.Pkg().Name() != "main" {
 			return true
 		}
 	}


### PR DESCRIPTION
In consideredUsed was used c.pkg that is not relevant to current
context. The value of c.pkg is "random", depends on order of map
values.

Fix #20
